### PR TITLE
Thesis Hyperlinks, Home Page Split Screen, News Feed

### DIFF
--- a/css/full-width-pics.css
+++ b/css/full-width-pics.css
@@ -265,7 +265,7 @@ ul.timeline > li:before{
   color: black;
   padding-left: 10px;
   padding-right: 10px;
-  padding-bottom: 10px;
+  padding-bottom: 20px;
   padding-top: none;
 }
 
@@ -277,6 +277,11 @@ ul.timeline > li:before{
 }
 
 .alumni-position{
+  font-size: 16px; 
+  font-weight: 400;
+}
+
+.alumni-thesis{
   font-size: 16px; 
   font-weight: 400;
 }

--- a/css/full-width-pics.css
+++ b/css/full-width-pics.css
@@ -155,7 +155,7 @@
   padding-right: 50px;
   padding-left: 50px;
   padding-bottom: 50px;
-  border-style: none solid none none;
+  border-style: none;
   border-color: #343a40;
   border-width: 3px;
 }

--- a/css/full-width-pics.css
+++ b/css/full-width-pics.css
@@ -145,6 +145,7 @@
 
 .split{
   display: flex;
+  height: 53vh;
 }
 
 .split-left{
@@ -167,11 +168,72 @@
   padding-bottom: 50px;
 }
 
-ul {
-    margin-left: 0;
-    padding-left: 20px;
+
+
+/****** Home Page News Carousel *******/
+
+/*news header*/
+isteColor{
+    color: #343a40;
+  }
+
+.isteColor:hover{
+    color: #0645AD;
+  }
+
+/*news content*/
+ul.timeline{
+  list-style-type: none;
+  position: relative;
 }
 
+ul.timeline:before{
+  content: ' ';
+  background: #d4d9df;
+  display: inline-block;
+  position: absolute;
+  left: 29px;
+  width: 2px;
+  height: 100%;
+  z-index: 400;
+}
+
+ul.timeline > li{
+  margin: 20px 0;
+  padding-left: 30px;
+}
+
+ul.timeline > li:before{
+  content: ' ';
+  background: white;
+  display: inline-block;
+  position: absolute;
+  border-radius: 50%;
+  border: 3px solid #343a40;
+  left: 20px;
+  width: 20px;
+  height: 20px;
+  z-index: 400;
+}
+
+/*carousel display*/
+.vert .carousel-item-next.carousel-item-left,
+.vert .carousel-item-prev.carousel-item-right{
+    -webkit-transform: translate3d(0, 0, 0);
+            transform: translate3d(0, 0, 0);
+}
+
+.vert .carousel-item-next,
+.vert .active.carousel-item-right{
+    -webkit-transform: translate3d(0, 100%, 0);
+            transform: translate3d(0, 100% 0);
+}
+
+.vert .carousel-item-prev,
+.vert .active.carousel-item-left{
+-webkit-transform: translate3d(0,-100%, 0);
+        transform: translate3d(0,-100%, 0);
+}
 
 
 /********* People Page CSS ***********/

--- a/css/full-width-pics.css
+++ b/css/full-width-pics.css
@@ -139,6 +139,41 @@
   font-family: sans-serif;
 }
 
+
+
+/****** Home Page Split Screen ********/
+
+.split{
+  display: flex;
+}
+
+.split-left{
+  width: 50%;
+  display: inline;
+  padding-top: 50px;
+  padding-right: 50px;
+  padding-left: 50px;
+  padding-bottom: 50px;
+  border-style: none solid none none;
+  border-color: #343a40;
+  border-width: 3px;
+}
+
+.split-right{
+  width: 50%;
+  padding-top: 50px;
+  padding-right: 50px;
+  padding-left: 50px;
+  padding-bottom: 50px;
+}
+
+ul {
+    margin-left: 0;
+    padding-left: 20px;
+}
+
+
+
 /********* People Page CSS ***********/
 
 .curr-member-container{

--- a/css/full-width-pics.css
+++ b/css/full-width-pics.css
@@ -166,6 +166,7 @@
   padding-right: 50px;
   padding-left: 50px;
   padding-bottom: 50px;
+  overflow: hidden;
 }
 
 

--- a/css/full-width-pics.css
+++ b/css/full-width-pics.css
@@ -145,7 +145,8 @@
 
 .split{
   display: flex;
-  height: 650px;
+  height: 650px; 
+  overflow: hidden
 }
 
 .split-left{
@@ -166,7 +167,6 @@
   padding-right: 50px;
   padding-left: 50px;
   padding-bottom: 50px;
-  overflow: hidden;
 }
 
 

--- a/css/full-width-pics.css
+++ b/css/full-width-pics.css
@@ -145,7 +145,7 @@
 
 .split{
   display: flex;
-  height: 53vh;
+  height: 650px;
 }
 
 .split-left{

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
 
     <!-- Custom styles for this template -->
     <link href="css/full-width-pics.css" rel="stylesheet">
+    <link href="//maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet" id="bootstrap-css">
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 
   </head>
 
@@ -65,16 +68,62 @@
       </div>
       
       <div class="split-right">
-        <h1>News</h1>
-        <ul>
-          <li>Article 1</li>
-          <li>Article 2</li>
-          <li>Article 3</li>
-          <li>Article 4</li>
-          <li>Article 5</li>
-      </div>
-        
-        
+        <div class="container">
+          <div class="row">
+            <div class="card border-dark golge">
+              <div class="card-header"><a class="isteColor">
+                <h5 class="text-center m-2" style="font-weight: bold">News</h5></a></div>
+              <div class="card-body">
+                <div class="carousel vert slide" data-ride="carousel" data-interval="4000">
+                  <div class="carousel-inner">
+                    <div class="carousel-item active">
+                      <ul class="timeline">
+                        <li>
+                          <a target="_blank" href="#">OpenSym’20 Accepted Paper</a>
+                          <a href="#" class="float-right">August 4, 2020</a>
+                          <p><i>Recommending Tasks to Newcomers in OSS Projects: How Do Mentors Handle It?</i> was accepted into the 16th International Symposium on Open Collaboration (OpenSym 2020).</p>
+                        </li>
+                        <hr>
+                        <li>
+                          <a href="#">ICSME’20 Accepted Paper</a>
+                          <a href="#" class="float-right">August 4, 2020</a>
+                          <p><i>Lifting the Curtain on Merge Conflict Resolution: A Sensemaking Perspective</i> was accepted for the 36th International Conference on Software Maintenance and Evolution (ICSME).</p>
+                        </li>
+                        <hr>
+                        <li>
+                         <a href="#">CSCW’20 Accepted Paper</a>
+                         <a href="#" class="float-right">July 24, 2020</a>
+                         <p><i>Hidden Figures: Roles and Pathways of Successful OSS Contributors</i> was accepted for the 23rd ACM Conference on Computer-Supported Cooperative Work and Social Computing (CSCW).</p>
+                       </li>
+                       </ul>
+                      </div>
+                    <div class="carousel-item">
+                      <ul class="timeline">
+                        <li>
+                          <a href="#">Congratulations Dr. Brindescu</a>
+                          <a href="#" class="float-right">July 7, 2020</a>
+                          <p>Congratulations to Dr. Brindescu for successfully defending his dissertation: <i>An Investigation of the effects of merge conflicts on collaborative software development</i>!</p>
+                       </li>
+                       <hr>
+                       <li>
+                          <a href="#">ICSE’20 Distinguished Paper Award</a>
+                          <a href="#" class="float-right">July 1, 2020</a>
+                          <p><i>A Tale from the Trenches: Cognitive Biases and Software Development</i> won an ACM SIGSOFT Distinguished Paper Award at ICSE 2020! Congratulations Team: Souti Chattopadhyay, Nicholas Nelson, Audrey Au, Natalia Morales, Christopher Sanchez, Rahul Pandita, Anita Sarma.</p>
+                       </li>
+                       <hr>
+                       <li>
+                          <a href="#">CHI’20 Honorable Mention</a>
+                          <a href="#" class="float-right">June 30, 2020</a>
+                          <p><i>What’s Wrong with Computational Notebooks? Pain Points, Needs, and Design Opportunities</i> received an honorable mention for CHI 2020! Congratulations team: Souti Chattopadhyay, Ishita Prasad, Austin Z. Henley, Anita Sarma & Titus Barik.</p>
+                       </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+  </div>
+</div>
     </section>
 
     <!-- Footer -->

--- a/index.html
+++ b/index.html
@@ -52,10 +52,10 @@
     </header>
 
     <!-- Content section -->
-    <section class="py-5">
-      <div class="container">
-        <h1>Dr. Anita Sarma's research group at Oregon State University</h1>
-        <p class="lead">EPICLabs stands for End-user centric, Privacy, Inclusion and Cognition.
+    <section class="split">
+      <div class="split-left">
+        <h2>Dr. Anita Sarma's research group at Oregon State University</h2>
+        <p class="lead"><br>EPICLabs stands for End-user centric, Privacy, Inclusion and Cognition.
           Our work follows an interdisciplinary approach of performing empirical user studies 
           to understand the problems and barriers that developers currently face, 
           designing and developing interactive tools to make developers and teams more efficient, and 
@@ -63,6 +63,18 @@
           is interdisciplinary, leveraging research in data mining, program analysis, software design, 
           software visualization, and human-computer interaction. </p>
       </div>
+      
+      <div class="split-right">
+        <h1>News</h1>
+        <ul>
+          <li>Article 1</li>
+          <li>Article 2</li>
+          <li>Article 3</li>
+          <li>Article 4</li>
+          <li>Article 5</li>
+      </div>
+        
+        
     </section>
 
     <!-- Footer -->

--- a/people.html
+++ b/people.html
@@ -211,133 +211,143 @@
 
         <div class="alumni-container">
             <a class="alumni-name">Caius Brindescu</a>
-            <p class="alumni-position">PhD, Oregon State University (2020) <br> Technical Staff, Etleap <br>Thesis</p>
+            <a class="alumni-position">PhD, Oregon State University (2020) <br> Technical Staff, Etleap</a>
+            <a class="alumni-thesis">Thesis</a>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Manideepa Saginatham</a>
-            <p class="alumni-position">MS, Oregon State University (2020)<br>Thesis</p>
+            <a class="alumni-position">MS, Oregon State University (2020)</a>
+            <a class="alumni-thesis">Thesis</a>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Marjan Adeli</a>
-            <p class="alumni-position">MS, Oregon State University (2020)<br><a href="https://ir.library.oregonstate.edu/concern/graduate_thesis_or_dissertations/5x21tn40d">Thesis</a></p>
+            <a class="alumni-position">MS, Oregon State University (2020)</a>
+            <a class="alumni-thesis"><a href="https://ir.library.oregonstate.edu/concern/graduate_thesis_or_dissertations/5x21tn40d">Thesis</a></a>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Sogol Balali</a>
-            <p class="alumni-position">MS, Oregon State University (2020) <br> Robotics Researcher, Computer Scientist, Oregon State University<br><a href="https://ir.library.oregonstate.edu/concern/graduate_thesis_or_dissertations/3t945z015">Thesis</a></p>
+            <a class="alumni-position">MS, Oregon State University (2020) <br> Robotics Researcher, Computer Scientist, Oregon State University</a>
+            <a class="alumni-thesis"><a href="https://ir.library.oregonstate.edu/concern/graduate_thesis_or_dissertations/3t945z015">Thesis</a></a>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Leif Tsang</a>
-            <p class="alumni-position">BE, Oregon State University (2020) <br> Recent Graduate Program, Naval Undersea Warfare Center (NUWC)</p>
+            <a class="alumni-position">BE, Oregon State University (2020) <br> Recent Graduate Program, Naval Undersea Warfare Center (NUWC)</a>
         </div>
     
         <div class="alumni-container">
             <a class="alumni-name">Evie May</a>
-            <p class="alumni-position">BS, Oregon State University (2020)</p>
+            <a class="alumni-position">BS, Oregon State University (2020)</a>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Yennifer Ramirez</a>
-            <p class="alumni-position">BS, Oregon State University (2020)</p>
+            <a class="alumni-position">BS, Oregon State University (2020)</a>
         </div>
 
         <div class="alumni-container">
             <a class="alumni-name">Thien L. Nam</a>
-            <p class="alumni-position">BS, Oregon State University (2020)</p>
+            <a class="alumni-position">BS, Oregon State University (2020)</a>
         </div>
 
         <div class="alumni-container">
             <a class="alumni-name">McKenzie Calvert</a>
-            <p class="alumni-position">BS, Oregon State University (2020)</p>
+            <a class="alumni-position">BS, Oregon State University (2020)</a>
         </div>
     
         <div class="alumni-container">
             <a class="alumni-name">Jillian R. Emard</a>
-            <p class="alumni-position">BS, Oregon State University (2019)</p>
+            <a class="alumni-position">BS, Oregon State University (2019)</a>
         </div>
     
         <div class="alumni-container">
             <a class="alumni-name">Susmita Padala</a>
-            <p class="alumni-position">BS, Oregon State University (2019) <br> Technical Program Manager, Microsoft</p>
+            <a class="alumni-position">BS, Oregon State University (2019) <br> Technical Program Manager, Microsoft</a>
         </div>
     
         <div class="alumni-container">
             <a class="alumni-name">Iftekhar Ahmed</a>
-            <p class="alumni-position">PhD, Oregon State University (2018) <br> Asst. Prof, University of California, Irvine<br><a href="https://ir.library.oregonstate.edu/concern/graduate_thesis_or_dissertations/9p290g400">Thesis</a></p>
+            <a class="alumni-position">PhD, Oregon State University (2018) <br> Asst. Prof, University of California, Irvine</a>
+            <a class="alumni-thesis"><a href="https://ir.library.oregonstate.edu/concern/graduate_thesis_or_dissertations/9p290g400">Thesis</a></a>
         </div>
     
         <div class="alumni-container"> 
             <a class="alumni-name">Umayal Annamalai</a>
-            <p class="alumni-position">BS, Oregon State University (2018) <br> Software Engineer, Act-On Software</p>
+            <a class="alumni-position">BS, Oregon State University (2018) <br> Software Engineer, Act-On Software</a>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Alex Hoffer</a>
-            <p class="alumni-position">BS, Oregon State University (2017) <br> Site Reliabilty Engineer, Kollective Technology</p>
+            <a class="alumni-position">BS, Oregon State University (2017) <br> Site Reliabilty Engineer, Kollective Technology</a>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Shane McKee</a>
-            <p class="alumni-position">MEng, Oregon State University (2016) <br> Software Engineer, Intel</p>
+            <a class="alumni-position">MEng, Oregon State University (2016) <br> Software Engineer, Intel</a>
         </div>
 
         <div class="alumni-container">
             <a class="alumni-name">Kevin North</a>
-            <p class="alumni-position">MS, University of Nebraska, Lincoln (2016) <br> Web Developer, Applied Systems<br><a href="https://digitalcommons.unl.edu/computerscidiss/103/">Thesis</a></p>
+            <a class="alumni-position">MS, University of Nebraska, Lincoln (2016) <br> Web Developer, Applied Systems</a>
+            <a class="alumni-thesis"><a href="https://digitalcommons.unl.edu/computerscidiss/103/">Thesis</a></a>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Bakhtiar Khan Kasi</a>
-            <p class="alumni-position">PhD, University of Nebraska, Lincoln (2015) <br> Dean, Assoc. Professor, Balochistan University of Information Technology, Engineering and Management Sciences<br><a href="https://digitalcommons.unl.edu/dissertations/AAI3738584/">Thesis</a></p>
+            <a class="alumni-position">PhD, University of Nebraska, Lincoln (2015) <br> Dean, Assoc. Professor, Balochistan University of Information Technology, Engineering and Management Sciences</a>
+            <a class="alumni-thesis"><a href="https://digitalcommons.unl.edu/dissertations/AAI3738584/">Thesis</a></a>
         </div>
 
         <div class="alumni-container">
             <a class="alumni-name">Xiaofan Chen</a>
-            <p class="alumni-position">PostDoc, University of Nebraska, Lincoln (2014-2015) <br> Lecturer, Massey University of New Zealand</p>
+            <a class="alumni-position">PostDoc, University of Nebraska, Lincoln (2014-2015) <br> Lecturer, Massey University of New Zealand</a>
         </div>
     
         <div class="alumni-container">
             <a class="alumni-name">Sandeep Kuttal</a>
-            <p class="alumni-position">PhD, University of Nebraska, Lincoln (2014) <br> Asst. Prof, University of Tulsa<br><a href="https://digitalcommons.unl.edu/dissertations/AAI3632730/">Thesis</a></p>
+            <a class="alumni-position">PhD, University of Nebraska, Lincoln (2014) <br> Asst. Prof, University of Tulsa</a>
+            <a class="alumni-thesis"><a href="https://digitalcommons.unl.edu/dissertations/AAI3632730/">Thesis</a></a>
         </div>
     
         <div class="alumni-container">
             <a class="alumni-name">Caleb Larsen</a>
-            <p class="alumni-position">BS, University of Nebraska, Lincoln (2014) <br> Software Engineer, RentVision</p>
+            <a class="alumni-position">BS, University of Nebraska, Lincoln (2014) <br> Software Engineer, RentVision</a>
         </div>
 
         <div class="alumni-container">
             <a class="alumni-name">Corey Jergensen</a>
-            <p class="alumni-position">MS, University of Nebraska, Lincoln (2013) <br> Software Engineer, Travefy<br><a href="https://digitalcommons.unl.edu/computerscidiss/63/">Thesis</a></p>
+            <a class="alumni-position">MS, University of Nebraska, Lincoln (2013) <br> Software Engineer, Travefy</a>
+            <a class="alumni-thesis"><a href="https://digitalcommons.unl.edu/computerscidiss/63/">Thesis</a></a>
         </div>
     
         <div class="alumni-container">
             <a class="alumni-name">Azrina Azmi Abdullah</a>
-            <p class="alumni-position">BS, University of Nebraska, Lincoln (2013) <br> Lead Teacher, Arus Academy</p>
+            <a class="alumni-position">BS, University of Nebraska, Lincoln (2013) <br> Lead Teacher, Arus Academy</a>
         </div>
 
         <div class="alumni-container">
             <a class="alumni-name">Megan Jensen</a>
-            <p class="alumni-position">BS, University of Nebraska, Lincoln (2013) <br> Lead Software Engineer, PenLink</p>
+            <a class="alumni-position">BS, University of Nebraska, Lincoln (2013) <br> Lead Software Engineer, PenLink</a>
         </div>
     
         <div class="alumni-container">
             <a class="alumni-name">Brad Hoff</a>
-            <p class="alumni-position">Undergraduate, University of Nebraska, Lincoln (2013)</p>
+            <a class="alumni-position">Undergraduate, University of Nebraska, Lincoln (2013)</a>
         </div>
 
       
         <div class="alumni-container">
             <a class="alumni-name">Jianguo Wang</a>
-            <p class="alumni-position">MS, University of Nebraska, Lincoln (2012) <br> Lead Software Engineer, Grab<br><a href="https://digitalcommons.unl.edu/computerscidiss/38/">Thesis</a></p>
+            <a class="alumni-position">MS, University of Nebraska, Lincoln (2012) <br> Lead Software Engineer, Grab</a>
+            <a class="alumni-thesis"><a href="https://digitalcommons.unl.edu/computerscidiss/38/">Thesis</a></a>
         </div>
 
         <div class="alumni-container">
             <a class="alumni-name">James Sukup</a>
-            <p class="alumni-position">Undergraduate, University of Nebraska, Lincoln (2012) <br> Software Engineer, EF Johnson Technologies, Inc.</p>
+            <a class="alumni-position">Undergraduate, University of Nebraska, Lincoln (2012) <br> Software Engineer, EF Johnson Technologies, Inc.</a>
         </div>
    
     </section>

--- a/people.html
+++ b/people.html
@@ -211,22 +211,22 @@
 
         <div class="alumni-container">
             <a class="alumni-name">Caius Brindescu</a>
-            <p class="alumni-position">PhD, Oregon State University (2020) <br> Technical Staff, Etleap</p>
+            <p class="alumni-position">PhD, Oregon State University (2020) <br> Technical Staff, Etleap <br>Thesis</p>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Manideepa Saginatham</a>
-            <p class="alumni-position">MS, Oregon State University (2020)</p>
+            <p class="alumni-position">MS, Oregon State University (2020)<br>Thesis</p>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Marjan Adeli</a>
-            <p class="alumni-position">MS, Oregon State University (2020)</p>
+            <p class="alumni-position">MS, Oregon State University (2020)<br><a href="https://ir.library.oregonstate.edu/concern/graduate_thesis_or_dissertations/5x21tn40d">Thesis</a></p>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Sogol Balali</a>
-            <p class="alumni-position">MS, Oregon State University (2020) <br> Robotics Researcher, Computer Scientist, Oregon State University</p>
+            <p class="alumni-position">MS, Oregon State University (2020) <br> Robotics Researcher, Computer Scientist, Oregon State University<br><a href="https://ir.library.oregonstate.edu/concern/graduate_thesis_or_dissertations/3t945z015">Thesis</a></p>
         </div>
       
         <div class="alumni-container">
@@ -266,7 +266,7 @@
     
         <div class="alumni-container">
             <a class="alumni-name">Iftekhar Ahmed</a>
-            <p class="alumni-position">PhD, Oregon State University (2018) <br> Asst. Prof, University of California, Irvine</p>
+            <p class="alumni-position">PhD, Oregon State University (2018) <br> Asst. Prof, University of California, Irvine<br><a href="https://ir.library.oregonstate.edu/concern/graduate_thesis_or_dissertations/9p290g400">Thesis</a></p>
         </div>
     
         <div class="alumni-container"> 
@@ -281,17 +281,17 @@
       
         <div class="alumni-container">
             <a class="alumni-name">Shane McKee</a>
-            <p class="alumni-position">MS, Oregon State University (2016) <br> Software Engineer, Intel</p>
+            <p class="alumni-position">MEng, Oregon State University (2016) <br> Software Engineer, Intel</p>
         </div>
 
         <div class="alumni-container">
             <a class="alumni-name">Kevin North</a>
-            <p class="alumni-position">MS, University of Nebraska, Lincoln (2016) <br> Web Developer, Applied Systems</p>
+            <p class="alumni-position">MS, University of Nebraska, Lincoln (2016) <br> Web Developer, Applied Systems<br><a href="https://digitalcommons.unl.edu/computerscidiss/103/">Thesis</a></p>
         </div>
       
         <div class="alumni-container">
             <a class="alumni-name">Bakhtiar Khan Kasi</a>
-            <p class="alumni-position">PhD, University of Nebraska, Lincoln (2015) <br> Dean, Assoc. Professor, Balochistan University of Information Technology, Engineering and Management Sciences</p>
+            <p class="alumni-position">PhD, University of Nebraska, Lincoln (2015) <br> Dean, Assoc. Professor, Balochistan University of Information Technology, Engineering and Management Sciences<br><a href="https://digitalcommons.unl.edu/dissertations/AAI3738584/">Thesis</a></p>
         </div>
 
         <div class="alumni-container">
@@ -301,7 +301,7 @@
     
         <div class="alumni-container">
             <a class="alumni-name">Sandeep Kuttal</a>
-            <p class="alumni-position">PhD, University of Nebraska, Lincoln (2014) <br> Asst. Prof, University of Tulsa</p>
+            <p class="alumni-position">PhD, University of Nebraska, Lincoln (2014) <br> Asst. Prof, University of Tulsa<br><a href="https://digitalcommons.unl.edu/dissertations/AAI3632730/">Thesis</a></p>
         </div>
     
         <div class="alumni-container">
@@ -311,7 +311,7 @@
 
         <div class="alumni-container">
             <a class="alumni-name">Corey Jergensen</a>
-            <p class="alumni-position">MS, University of Nebraska, Lincoln (2013) <br> Software Engineer, Travefy</p>
+            <p class="alumni-position">MS, University of Nebraska, Lincoln (2013) <br> Software Engineer, Travefy<br><a href="https://digitalcommons.unl.edu/computerscidiss/63/">Thesis</a></p>
         </div>
     
         <div class="alumni-container">
@@ -332,7 +332,7 @@
       
         <div class="alumni-container">
             <a class="alumni-name">Jianguo Wang</a>
-            <p class="alumni-position">MS, University of Nebraska, Lincoln (2012) <br> Lead Software Engineer, Grab</p>
+            <p class="alumni-position">MS, University of Nebraska, Lincoln (2012) <br> Lead Software Engineer, Grab<br><a href="https://digitalcommons.unl.edu/computerscidiss/38/">Thesis</a></p>
         </div>
 
         <div class="alumni-container">

--- a/publications.html
+++ b/publications.html
@@ -61,7 +61,7 @@
       
     <section>
       <div class="article container">
-        <a class="title">Supporting Code Comprehension via Annotations: Right Information at the Right Time and Place</a>
+        <a class="title">On the Relationship Between Design Discussions and Design Quality: A Case Study of Apache Projects</a>
         <span class="author"><a href="https://epiclab.github.io/people.html">Umme Ayda Mannan</a>, <a href="https://www.ics.uci.edu/~iftekha/">Iftekhar Ahmed</a>, <a href="http://web.engr.oregonstate.edu/~jensenca/OSU_ENGR/index.html">Carlos Jensen</a>, and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
         <span class="venue">ACM 28th SIGSOFT International Symposium on Foundations of Software Engineering (FSE), 2020.</span>
       </div>

--- a/publications.html
+++ b/publications.html
@@ -51,7 +51,21 @@
     </nav>
 
     <!-- Content section -->
-
+    <section>
+      <div class="article container">
+        <a class="title">Recommending Tasks to Newcomers in OSS Projects: How Do Mentors Handle It?</a>
+        <span class="author">Sogol Balali, Umayal Annamalai, Susmita Padala, Bianca Trinkenreich, <a href="https://www.ime.usp.br/~gerosa/">Marco Aurelio Gerosa</a>, <a href="https://www.igor.pro.br/">Igor Steinmacher</a>, and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
+        <span class="venue">16th International Symposium on Open Collaboration (OpenSym), 2020.</span>
+      </div>
+    </section>
+      
+    <section>
+      <div class="article container">
+        <a class="title">Supporting Code Comprehension via Annotations: Right Information at the Right Time and Place</a>
+        <span class="author"><a href="https://epiclab.github.io/people.html">Umme Ayda Mannan</a>, <a href="https://www.ics.uci.edu/~iftekha/">Iftekhar Ahmed</a>, <a href="http://web.engr.oregonstate.edu/~jensenca/OSU_ENGR/index.html">Carlos Jensen</a>, and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
+        <span class="venue">ACM 28th SIGSOFT International Symposium on Foundations of Software Engineering (FSE), 2020.</span>
+      </div>
+    </section>
 
     <section>
       <div class="article container">
@@ -79,8 +93,7 @@
 
     <section>
       <div class="article container">
-        <a class="title" ID="paper-link" href="https://epiclab.github.io/ICSE20-CogBias/">A Tale from the Trenches: Cognitive Biases and Software Development
-          <i class="fas fa-link" ID="popup"></i></a>
+        <a class="title">A Tale from the Trenches: Cognitive Biases and Software Development</a>
         <span class="author"><a href="https://epiclab.github.io/people.html">Souti Chattopadhyay</a>, <a href="https://epiclab.github.io/people.html">Nicholas Nelson</a>, Audrey Au, Natalia Morales, <a href="http://people.oregonstate.edu/~sancchri/">Christopher Sanchez</a>, <a href="http://rahulpandita.me/">Rahul Pandita</a>, and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
         <span class="venue">IEEE/ACM 42nd International Conference on Software Engineering (ICSE), 2020.</span>
       </div>
@@ -142,7 +155,7 @@
 
     <section>
       <div class="article container">
-        <a class="title" href="https://epiclab.github.io/ICSE19-LatentPatternsInActivities/">Latent Patterns in Activities: A Field Study of How Developers Manage Context
+        <a class="title" href="https://dl.acm.org/doi/10.1109/ICSE.2019.00051">Latent Patterns in Activities: A Field Study of How Developers Manage Context
           <i class="fas fa-link" ID="popup"></i></a></a>
       <span class="author"><a href="https://epiclab.github.io/people.html">Souti Chattopadhyay</a>, <a href="https://epiclab.github.io/people.html">Nicholas Nelson</a>, Yenifer Ramirez Gonzalez, Annel Amelia Leon, <a href="http://rahulpandita.me/">Rahul Pandita</a>, and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
         <span class="venue">IEEE/ACM 41st International Conference on Software Engineering (ICSE), 2019.</span>
@@ -205,6 +218,15 @@
 
     <section>
       <div class="article container">
+        <a class="title" href="https://dl.acm.org/doi/10.1145/3283812.3283820">Towards Understanding Code Readability and Its impact on Design Quality
+          <i class="fas fa-link" ID="popup"></i></a></a>
+        <span class="author"><a href="https://epiclab.github.io/people.html">Umme Ayda Mannan</a>, <a href="https://www.ics.uci.edu/~iftekha/">Iftekhar Ahmed</a>, and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
+        <span class="venue">ACM 4th International Workshop on NLP for Software Engineering (NL4SE), pp. 18-21, 2018.</span>
+      </div>
+    </section>
+
+    <section>
+      <div class="article container">
         <a class="title" href="https://dl.acm.org/doi/10.1145/3180155.3180241">Open Source barriers to entry, revisited: A socio technical perspective
           <i class="fas fa-link" ID="popup"></i></a></a>
         <span class="author">Christopher Mendez, Hema Susmita Padala, Zoe Steine-Hanson, Claudia Hilderbrand, <a href="https://horvathaa.github.io/">Amber Horvath</a>, Charles Hill, Logan Simpson, Nupoor Patil, <a href="https://epiclab.github.io/people.html">Anita Sarma</a>, and <a href="http://web.engr.oregonstate.edu/~burnett/">Margaret Burnett</a></span>
@@ -244,7 +266,7 @@
         <a class="title" href="https://ieeexplore.ieee.org/abstract/document/8094445">Software Practitioner Perspectives on Merge Conflicts and Resolutions
           <i class="fas fa-link" ID="popup"></i></a></a>
         <span class="author">Shane McKee, <a href="https://epiclab.github.io/people.html">Nicholas Nelson</a>, <a href="https://epiclab.github.io/people.html">Anita Sarma</a>, and <a href="http://dig.cs.illinois.edu/">Danny Dig</a></span>
-        <span class="venue">IEEE International Conference on Software Maintenance and Evolution (ICSME), 2017.</span>
+        <span class="venue">IEEE International Conference on Software Maintenance and Evolution (ICSME), pp. 467-478, 2017.</span>
       </div>
     </section>
 
@@ -280,7 +302,7 @@
         <a class="title" href="https://ieeexplore.ieee.org/document/8170085">An Empirical Examination of the Relationship between Code Smells and Merge Conflicts
           <i class="fas fa-link" ID="popup"></i></a></a>
         <span class="author"><a href="https://www.ics.uci.edu/~iftekha/">Iftekhar Ahmed</a>, <a href="http://caius.brindescu.com/">Caius Brindescu</a>, <a href="https://epiclab.github.io/people.html">Umme Ayda Mannan</a>, <a href="http://web.engr.oregonstate.edu/~jensenca/OSU_ENGR/index.html">Carlos Jensen</a>, and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
-        <span class="venue">ACM/IEEE International Symposium on Empirical Software Engineering and Measurement (ESEM), 2017.</span>
+        <span class="venue">IEEE/ACM International Symposium on Empirical Software Engineering and Measurement (ESEM), pp. 58-67, 2017.</span>
       </div>
     </section>
                         
@@ -290,6 +312,15 @@
           <i class="fas fa-link" ID="popup"></i></a></a>
         <span class="author">Catarina Costa, Jair Figueiredo, <a href="https://epiclab.github.io/people.html">Anita Sarma</a>, and <a href="http://www.ic.uff.br/~leomurta/">Leonardo Murta</a></span>
         <span class="venue">ACM 24th SIGSOFT International Symposium on Foundations of Software Engineering (FSE), pp. 998-1002, 2016.</span>
+      </div>
+    </section>
+
+    <section>
+      <div class="article container">
+        <a class="title" href="https://ieeexplore.ieee.org/document/7832986/">Understanding Code Smells in Android Applications
+          <i class="fas fa-link" ID="popup"></i></a></a>
+        <span class="author"><a href="https://epiclab.github.io/people.html">Umme Ayda Mannan</a>, <a href="https://www.ics.uci.edu/~iftekha/">Iftekhar Ahmed</a>, Rana Almurshed, <a href="http://dig.cs.illinois.edu/">Danny Dig</a>, and <a href="http://web.engr.oregonstate.edu/~jensenca/OSU_ENGR/index.html">Carlos Jensen</a></span>
+        <span class="venue">IEEE/ACM International Conference on Mobile SOftware Engineering and Systems (MOBILESoft), pp. 225-236, 2016.</span>
       </div>
     </section>
 
@@ -349,10 +380,19 @@
 
     <section>
       <div class="article container">
-        <a class="title" href="https://dl.acm.org/doi/10.1145/2786805.2803199">GitSonifier: Using Sound to Portray Developer Conflict History,
+        <a class="title" href="https://dl.acm.org/doi/10.1145/2786805.2803199">GitSonifier: Using Sound to Portray Developer Conflict History
           <i class="fas fa-link" ID="popup"></i></a></a>
         <span class="author">Kevin J. North, Shane Bolan, <a href="https://epiclab.github.io/people.html">Anita Sarma</a>, and <a href="http://web.cs.iastate.edu/~mcohen/">Myra B. Cohen</a></span>
         <span class="venue">ACM 10th Joint Meeting on Foundations of Software Engineering (ESEC/FSE), pp. 886–889, 2015.</span>
+      </div>
+    </section>
+
+    <section>
+      <div class="article container">
+        <a class="title" href="https://ieeexplore.ieee.org/document/7321186">An Empirical Study of Design Degradation: How Software Projects Get Worse over Time
+          <i class="fas fa-link" ID="popup"></i></a></a>
+        <span class="author"><a href="https://www.ics.uci.edu/~iftekha/">Iftekhar Ahmed</a>, <a href="https://epiclab.github.io/people.html">Umme Ayda Mannan</a>, <a href="https://rahul.gopinath.org/">Rahul Gopinath</a>, and <a href="http://web.engr.oregonstate.edu/~jensenca/OSU_ENGR/index.html">Carlos Jensen</a></span>
+        <span class="venue">IEEE/ACM International Symposium on Empirical Software Engineering and Measurement (ESEM), pp. 1-10, 2015.</span>
       </div>
     </section>
 
@@ -380,6 +420,24 @@
           <i class="fas fa-link" ID="popup"></i></a></a>
         <span class="author">Kerry Hart and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
         <span class="venue">ACM 7th International Workshop on Cooperative and Human Aspects of Software Engineering (CHASE), pp. 103-106, 2014.</span>
+      </div>
+    </section>
+
+    <section>
+      <div class="article container">
+        <a class="title" href="https://dl.acm.org/doi/10.1145/2641580.2641589">Older Adults and Free/Open Source Software: A Diary Study of First-Time Contributors
+          <i class="fas fa-link" ID="popup"></i></a></a>
+        <span class="author">Jennifer Davidson, <a href="https://epiclab.github.io/people.html">Umme Ayda Mannan</a>, Rithika Naik, Ishnit Dua, and <a href="http://web.engr.oregonstate.edu/~jensenca/OSU_ENGR/index.html">Carlos Jensen</a></span>
+        <span class="venue">International Symposium on Open Collaboration (OpenSym), pp. 1-10, 2014.</span>
+      </div>
+    </section>
+
+    <section>
+      <div class="article container">
+        <a class="title" href="https://ieeexplore.ieee.org/document/6883029">On older adults in free/open source software: reflections of contributors and community leaders
+          <i class="fas fa-link" ID="popup"></i></a></a>
+        <span class="author">Jennifer Davidson, <a href="https://epiclab.github.io/people.html">Umme Ayda Mannan</a>, Rithika Naik, Amir Hossain Azarbakht, and <a href="http://web.engr.oregonstate.edu/~jensenca/OSU_ENGR/index.html">Carlos Jensen</a></span>
+        <span class="venue">International Symposium on Visual Languages and Human-Centric Computing (VL/HCC), pp. 93-100, 2014.</span>
       </div>
     </section>
 
@@ -441,7 +499,7 @@
         <a class="title" href="https://dl.acm.org/doi/10.1145/2470654.2466213">Debugging Support for End-User Mashup Programming
           <i class="fas fa-link" ID="popup"></i></a></a>
         <span class="author"><a href="http://sandeepkuttal.ens.utulsa.edu/index.html">Sandeep Kaur Kuttal</a>, <a href="https://epiclab.github.io/people.html">Anita Sarma</a>, and <a href="http://cse.unl.edu/~grother/">Gregg Rothermel</a></span>
-        <span class="venue">IEEE/ACM SIGCHI Conference on Human Factors in Computing Systems (CHI), pp. 1609-1618, 2013.</span>
+        <span class="venue">ACM SIGCHI Conference on Human Factors in Computing Systems (CHI), pp. 1609-1618, 2013.</span>
       </div>
     </section>
 
@@ -450,7 +508,7 @@
         <a class="title" href="https://www.sciencedirect.com/science/article/abs/pii/S095058491200211X?via%3Dihub">Discovering how end-user programmers and their communities use public repositories: A study on Yahoo! Pipes
           <i class="fas fa-link" ID="popup"></i></a></a>
         <span class="author"><a href="https://kstolee.github.io/">Kathryn T. Stolee</a>, <a href="https://cse.unl.edu/~elbaum/content/">Sebastian Elbaum</a>, and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
-        <span class="venue">Journal on Information and Software Technology, Volume 55, Issue 7 pp. 1289-1303, 2012.</span>
+        <span class="venue">Journal on Information and Software Technology, Volume 55, Issue 7, pp. 1289-1303, 2012.</span>
       </div>
     </section>                         
                            
@@ -468,7 +526,7 @@
         <a class="title" href="https://dl.acm.org/doi/10.1109/ESEM.2011.23">End-User Programmers and their Communities: An Artifact-based Analysis
           <i class="fas fa-link" ID="popup"></i></a></a>
         <span class="author"><a href="https://kstolee.github.io/index.html">Kathryn T. Stolee</a>, <a href="http://cse.unl.edu/~elbaum/content/">Sebastian Elbaum</a> and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
-        <span class="venue">ACM/IEEE International Symposium on Empirical Software Engineering and Measurement (ESEM), pp. 147-156, 2011.</span>
+        <span class="venue">IEEE/ACM International Symposium on Empirical Software Engineering and Measurement (ESEM), pp. 147-156, 2011.</span>
       </div>
     </section>
 

--- a/publications.html
+++ b/publications.html
@@ -93,7 +93,8 @@
 
     <section>
       <div class="article container">
-        <a class="title">A Tale from the Trenches: Cognitive Biases and Software Development</a>
+        <a class="title" ID="paper-link" href="https://epiclab.github.io/ICSE20-CogBias/">A Tale from the Trenches: Cognitive Biases and Software Development
+        <i class="fas fa-link" ID="popup"></i></a>
         <span class="author"><a href="https://epiclab.github.io/people.html">Souti Chattopadhyay</a>, <a href="https://epiclab.github.io/people.html">Nicholas Nelson</a>, Audrey Au, Natalia Morales, <a href="http://people.oregonstate.edu/~sancchri/">Christopher Sanchez</a>, <a href="http://rahulpandita.me/">Rahul Pandita</a>, and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
         <span class="venue">IEEE/ACM 42nd International Conference on Software Engineering (ICSE), 2020.</span>
       </div>
@@ -155,7 +156,7 @@
 
     <section>
       <div class="article container">
-        <a class="title" href="https://dl.acm.org/doi/10.1109/ICSE.2019.00051">Latent Patterns in Activities: A Field Study of How Developers Manage Context
+        <a class="title" href="https://epiclab.github.io/ICSE19-LatentPatternsInActivities/">Latent Patterns in Activities: A Field Study of How Developers Manage Context
           <i class="fas fa-link" ID="popup"></i></a></a>
       <span class="author"><a href="https://epiclab.github.io/people.html">Souti Chattopadhyay</a>, <a href="https://epiclab.github.io/people.html">Nicholas Nelson</a>, Yenifer Ramirez Gonzalez, Annel Amelia Leon, <a href="http://rahulpandita.me/">Rahul Pandita</a>, and <a href="https://epiclab.github.io/people.html">Anita Sarma</a></span>
         <span class="venue">IEEE/ACM 41st International Conference on Software Engineering (ICSE), 2019.</span>


### PR DESCRIPTION
added thesis hyperlinks to alumni (MS and PhD), a split content display on the home page, a news feed, and some starting articles (which need their own pages in the future so that we can hyperlink them); also updated publications